### PR TITLE
Remove volatile declaration from AIisThinking

### DIFF
--- a/include/events.h
+++ b/include/events.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-extern volatile bool AIisThinking;
+extern bool AIisThinking;
 
 void leftClickEvent(int x, int y, bool playerGame);
 void rightClickEvent(void);

--- a/src/events.c
+++ b/src/events.c
@@ -5,7 +5,7 @@
 
 #include <stddef.h>
 
-volatile bool AIisThinking;
+bool AIisThinking;
 
 static uint16_t moves[64];
 static int numMoves;


### PR DESCRIPTION
This variable is synchronized and the `volatile` serves no purpose.