### PR TITLE
Switch Win32 from Condition Variable to Event

### DIFF
--- a/include/windows_common.h
+++ b/include/windows_common.h
@@ -7,9 +7,7 @@
 extern HDC windowDC;
 extern HDC frameBufferDC;
 
-extern CONDITION_VARIABLE cond;
-extern SRWLOCK lock;
-extern volatile bool AIThreadWakeup;
+extern HANDLE event;
 
 void windowsBlitToScreen(void);
 void *windowsLoadFile(const char *fileName);

--- a/src/windows_common.c
+++ b/src/windows_common.c
@@ -12,9 +12,7 @@
 HDC windowDC;
 HDC frameBufferDC;
 
-CONDITION_VARIABLE cond = CONDITION_VARIABLE_INIT;
-SRWLOCK lock = SRWLOCK_INIT;
-volatile bool AIThreadWakeup;
+HANDLE event;
 
 void windowsBlitToScreen(void)
 {
@@ -108,8 +106,5 @@ void windowsDebugLog(const char *message)
 
 void windowsMakeComputerMove(void)
 {
-	AcquireSRWLockExclusive(&lock);
-	AIThreadWakeup = true;
-	ReleaseSRWLockExclusive(&lock);
-	WakeConditionVariable(&cond);
+	SetEvent(event);
 }

--- a/src/windows_main.c
+++ b/src/windows_main.c
@@ -122,13 +122,7 @@ static DWORD AIThreadLoop(_In_ LPVOID lpParameter)
 	HWND window = lpParameter;
 	while (true)
 	{
-		AcquireSRWLockExclusive(&lock);
-		while (!AIThreadWakeup)
-		{
-			SleepConditionVariableSRW(&cond, &lock, INFINITE, 0);
-		}
-		AIThreadWakeup = false;
-		ReleaseSRWLockExclusive(&lock);
+		WaitForSingleObject(event, INFINITE);
 		uint16_t move = getComputerMove();
 		PostMessageA(window, WM_USER, move, 0);
 	}
@@ -227,12 +221,12 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 	if (strcmp(lpCmdLine, "-ai") == 0)
 	{
 		AIisThinking = true;
-		AIThreadWakeup = true;
 	}
 	else
 	{
 		playerGame = true;
 	}
+	event = CreateEventA(NULL, FALSE, AIisThinking, NULL);
 	if (CreateThread(NULL, 0, AIThreadLoop, window, 0, NULL) == NULL)
 	{
 		OutputDebugStringA("CreateThread failed\r\n");


### PR DESCRIPTION
Not only does this simplify synchronization, it's more portable, allowing the program to work on much older versions of Windows. The Event automatically resets when the AI thread wakes from it. Returning from `WaitForSingleObject` is equivalent to acquiring a lock, and `PostMessageA` is equivalent to releasing that lock. For the UI thread it's reversed: the receipt of `WM_USER` message acquires the "lock", and `SetEvent` releases it.

I don't know whether you prefer to explicitly free the Event with `CloseHandle` just before the program exits, or allow this to happen implicitly, since its lifetime is the entire program anyway. Unlike the original synchronization objects, an Event is a kernel object.